### PR TITLE
Don't apply handbrake to train cars without an interactable handbrake

### DIFF
--- a/RollingStockOwnership/CommsRadio/EquipmentPurchaser/PurchaseConfirmer.cs
+++ b/RollingStockOwnership/CommsRadio/EquipmentPurchaser/PurchaseConfirmer.cs
@@ -133,7 +133,7 @@ internal class PurchaseConfirmer : AStateBehaviour
 	private static IEnumerator CheckHandbrakeNextFrame(TrainCar trainCar)
 	{
 		yield return null;
-		if (!trainCar.trainset.cars.Any(car => car.brakeSystem.brakeset.anyHandbrakeApplied))
+		if (trainCar.brakeSystem.hasHandbrake && !trainCar.trainset.cars.Any(car => car.brakeSystem.brakeset.anyHandbrakeApplied))
 		{
 			trainCar.brakeSystem.handbrakePosition = 1f;
 		}


### PR DESCRIPTION
This issue caused the S282A to spawn with its handbrake applied when purchased, leaving the player without the ability to release it. Fixes #38 with future proofing for CCL compatibility.