### PR TITLE
Package and load offline translations

### DIFF
--- a/RollingStockOwnership/Main.cs
+++ b/RollingStockOwnership/Main.cs
@@ -2,6 +2,7 @@
 using RollingStockOwnership.Patches;
 using HarmonyLib;
 using System;
+using System.IO;
 using System.Reflection;
 using UnityEngine;
 using UnityModManagerNet;
@@ -49,6 +50,7 @@ public static class Main
 			harmony.PatchAll(Assembly.GetExecutingAssembly());
 
 			var translations = new TranslationInjector("fauxnik/dv-rolling-stock-ownership");
+			translations.AddTranslationsFromCsv(Path.Combine(modEntry.Path, "offline_translations.csv"));
 			translations.AddTranslationsFromWebCsv("https://docs.google.com/spreadsheets/d/e/2PACX-1vQGeGpv-zk-TxxN3c87vjhtwJdP2oOYeJHF5nI2cJshF7mrNGHTeqQFOda0fo-zOltSRfNdT_nrHNiW/pub?gid=1191351766&single=true&output=csv");
 		}
 		catch (Exception e) { OnCriticalFailure(e, "patching miscellaneous assembly"); }

--- a/package.ps1
+++ b/package.ps1
@@ -20,6 +20,7 @@ $ZipOutDir = "$ZipWorkDir/$modId"
 
 New-Item "$ZipOutDir" -ItemType Directory -Force
 Copy-Item -Force -Path $FilesToInclude -Destination "$ZipOutDir"
+Invoke-WebRequest -OutFile "$ZipOutDir/offline_translations.csv" -Uri "https://docs.google.com/spreadsheets/d/e/2PACX-1vQGeGpv-zk-TxxN3c87vjhtwJdP2oOYeJHF5nI2cJshF7mrNGHTeqQFOda0fo-zOltSRfNdT_nrHNiW/pub?gid=1191351766&single=true&output=csv"
 
 if (!$NoArchive)
 {


### PR DESCRIPTION
This is necessary for delivering translations to Chinese players who are blocked from accessing Google spreadsheets by the Great Firewall. Download of the CSV happens automatically anytime the ZIP archive is packaged for distribution, so it can't be forgotten when preparing a new distribution. Players who can access Google spreadsheets _should_ get the latest translations—even if their copy of the mod includes an older CSV—because the online translations are also imported _after_ the packaged CSV, thus overwriting the offline translations.