### PR TITLE
Fix starter loco not spawning in front of player home

### DIFF
--- a/RollingStockOwnership/CommsRadio/EquipmentPurchaser/DestinationPicker.cs
+++ b/RollingStockOwnership/CommsRadio/EquipmentPurchaser/DestinationPicker.cs
@@ -103,6 +103,7 @@ internal class DestinationPicker : AStateBehaviour
 			case InputAction.Activate:
 				if (IsPlaceable(selectedCarType, selectedTrack, selectedPoint))
 				{
+					Main.LogDebug(() => $"Selected track: {selectedTrack.logicTrack.ID.FullID}");
 					utility.PlaySound(VanillaSoundCommsRadio.Confirm);
 					return new PurchaseConfirmer(selectedCarType, selectedTrack, selectedPoint.Value, isSelectedOrientationOppositeTrackDirection, destinationHighlighter);
 				}

--- a/RollingStockOwnership/CommsRadio/EquipmentPurchaser/TrainCarTypePicker.cs
+++ b/RollingStockOwnership/CommsRadio/EquipmentPurchaser/TrainCarTypePicker.cs
@@ -43,6 +43,7 @@ internal class TrainCarTypePicker : AStateBehaviour
 				if (Finance.CanAfford(selectedCarType))
 				{
 					if (!carBounds.HasValue) { throw new Exception($"Can't find car bounds for car type: {selectedCarType}"); }
+					Main.LogDebug(() => $"Selected livery: {selectedCarType}");
 					utility.PlaySound(VanillaSoundCommsRadio.Confirm);
 					return new DestinationPicker(selectedCarType, carBounds.Value, utility.SignalOrigin);
 				}

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -15,7 +15,11 @@ namespace RollingStockOwnership;
 
 internal static class StartingConditions
 {
-	private static readonly string playerHomeTrackID = "#Y-#S-194-#T";
+	private static readonly Vector3 starterLocoSpawnPosition = new Vector3(
+		5698.63135f,
+		155.929153f,
+		7622.781f
+	);
 	private static readonly TrainCarLivery[] startingWagons = {
 		TrainCarType.FlatbedStakes.ToV2(),
 		TrainCarType.FlatbedStakes.ToV2(),
@@ -68,9 +72,6 @@ internal static class StartingConditions
 	{
 		yield return new WaitForSeconds(1);
 
-		List<RailTrack> allTracks = new List<RailTrack>(RailTrackRegistry.Instance.AllTracks);
-		RailTrack playerHomeTrack = allTracks.Find(track => track.logicTrack.ID.FullID == playerHomeTrackID);
-
 		Inventory inventory = Inventory.Instance;
 		UnusedTrainCarDeleter unusedTrainCarDeleter = UnusedTrainCarDeleter.Instance;
 		CarSpawner carSpawner = CarSpawner.Instance;
@@ -88,7 +89,20 @@ internal static class StartingConditions
 			);
 		}
 
-		IEnumerable<Equipment> spawnedEquipment = carSpawner.SpawnCarTypesOnTrackRandomOrientation(new List<TrainCarLivery> { starterLoco.ToV2() }, playerHomeTrack, true, true)
+		bool flipRotation = false;
+		bool playerSpawnedCar = false;
+		bool uniqueCar = false;
+		IEnumerable<Equipment> spawnedEquipment =
+			new List<TrainCar>
+			{
+				carSpawner.SpawnCarOnClosestTrack(
+					starterLocoSpawnPosition + WorldMover.currentMove,
+					starterLoco.ToV2(),
+					flipRotation,
+					playerSpawnedCar,
+					uniqueCar
+				)
+			}
 			.Select(Equipment.FromTrainCar);
 
 		foreach (Equipment equipment in spawnedEquipment)

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -15,7 +15,7 @@ namespace RollingStockOwnership;
 
 internal static class StartingConditions
 {
-	private static readonly string playerHomeTrackID = "#Y-#S-392-#T";
+	private static readonly string playerHomeTrackID = "#Y-#S-194-#T";
 	private static readonly TrainCarLivery[] startingWagons = {
 		TrainCarType.FlatbedStakes.ToV2(),
 		TrainCarType.FlatbedStakes.ToV2(),

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -146,7 +146,7 @@ internal static class StartingConditions
 				title: "Rolling Stock Ownership",
 				message: string.Join(" ", new string [] {
 					isShuntingLicenseChanged ? LocalizationAPI.L("given_shunting_license") : "",
-					LocalizationAPI.L("given_starter_equipment", new string[] { locoName }),
+					LocalizationAPI.L("given_starter_equipment", new string [] { locoName }),
 				}),
 				positive: LocalizationAPI.L("given_starter_equipment_positive")
 			)


### PR DESCRIPTION
This started happening after build 98 because the track ID changed.

This PR decouples the spawning of the starter locomotive from any track ID, which also makes it less susceptible to being broken by future updates.