### PR TITLE
Clear rolling stock registry when loading save data

### DIFF
--- a/RollingStockOwnership/RollingStockManager.cs
+++ b/RollingStockOwnership/RollingStockManager.cs
@@ -90,7 +90,7 @@ public class RollingStockManager
 	}
 
 	// Simply calling registry.Clear() won't suffice because the IDs must also be removed from IdGenerator
-	private void Clear()
+	internal void Clear()
 	{
 		Main.Log($"Clearing rolling stock registry of {registry.Count} entries");
 
@@ -103,8 +103,6 @@ public class RollingStockManager
 
 	public void LoadSaveData(JArray data)
 	{
-		Clear();
-
 		int countLoaded = 0, countTotal = 0;
 		foreach(var token in data)
 		{

--- a/RollingStockOwnership/RollingStockManager.cs
+++ b/RollingStockOwnership/RollingStockManager.cs
@@ -4,13 +4,14 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using DV.Utils;
 
 namespace RollingStockOwnership;
 
-public class RollingStockManager : SingletonBehaviour<RollingStockManager>
+public class RollingStockManager
 {
-	public static new string AllowAutoCreate() { return "[RollingStockOwnership_RollingStockManager]"; }
+	private static RollingStockManager? instance = null;
+	public static RollingStockManager Instance { get => instance ??= new RollingStockManager(); }
+
 	public static readonly object syncLock = new object();
 
 	private List<Equipment> registry = new List<Equipment>();
@@ -88,9 +89,22 @@ public class RollingStockManager : SingletonBehaviour<RollingStockManager>
 		return equipments.ToList();
 	}
 
+	// Simply calling registry.Clear() won't suffice because the IDs must also be removed from IdGenerator
+	private void Clear()
+	{
+		Main.Log($"Clearing rolling stock registry of {registry.Count} entries");
+
+		// AllEquipment returns a new List, otherwise Remove will modify the enumerable under iteration
+		foreach (Equipment equipment in AllEquipment)
+		{
+			Remove(equipment);
+		}
+	}
+
 	public void LoadSaveData(JArray data)
 	{
-		registry.Clear();
+		Clear();
+
 		int countLoaded = 0, countTotal = 0;
 		foreach(var token in data)
 		{

--- a/RollingStockOwnership/RollingStockManager.cs
+++ b/RollingStockOwnership/RollingStockManager.cs
@@ -90,6 +90,7 @@ public class RollingStockManager : SingletonBehaviour<RollingStockManager>
 
 	public void LoadSaveData(JArray data)
 	{
+		registry.Clear();
 		int countLoaded = 0, countTotal = 0;
 		foreach(var token in data)
 		{

--- a/RollingStockOwnership/SaveManager.cs
+++ b/RollingStockOwnership/SaveManager.cs
@@ -51,6 +51,9 @@ public class SaveManager
 			SaveGameManager saveGameManager = SaveGameManager.Instance;
 			try
 			{
+				// Any previously loaded data must be cleared before loading new data
+				RollingStockManager.Instance.Clear();
+
 				JObject saveData = saveGameManager.data.GetJObject(PRIMARY_SAVE_KEY);
 
 				// Data migration for old save data


### PR DESCRIPTION
This resolves issues with loading a save after another save has already been loaded.