### PR TITLE
Prevent SU jobs from creating too small of groups

### DIFF
--- a/RollingStockOwnership/Utilities.cs
+++ b/RollingStockOwnership/Utilities.cs
@@ -37,11 +37,15 @@ public static class Utilities
 			}
 			else
 			{
-				numCarsForCurrentTrack = rng.Next(1, averageNumCarsPerTrack + 1);
+				numCarsForCurrentTrack = rng.Next(minCarsPerTrack, averageNumCarsPerTrack + 1);
 			}
 			if (numCarsForCurrentTrack < 1)
 			{
 				Main.LogError("Assigned zero cars to a track. This should never happen!");
+			}
+			if (numCarsForCurrentTrack < minCarsPerTrack)
+			{
+				Main.LogWarning($"Assigned {numCarsForCurrentTrack} to a track, but minCarsPerTrack is {minCarsPerTrack}");
 			}
 			numCarsPerTracks.Add(numCarsForCurrentTrack);
 			numCarsAccountedFor += numCarsForCurrentTrack;

--- a/RollingStockOwnership/Utilities.cs
+++ b/RollingStockOwnership/Utilities.cs
@@ -45,7 +45,7 @@ public static class Utilities
 			}
 			if (numCarsForCurrentTrack < minCarsPerTrack)
 			{
-				Main.LogWarning($"Assigned {numCarsForCurrentTrack} to a track, but minCarsPerTrack is {minCarsPerTrack}");
+				Main.LogWarning($"Assigned {numCarsForCurrentTrack} cars to a track, but minCarsPerTrack is {minCarsPerTrack}");
 			}
 			numCarsPerTracks.Add(numCarsForCurrentTrack);
 			numCarsAccountedFor += numCarsForCurrentTrack;


### PR DESCRIPTION
The random number generator was using an incorrect lower bound.