### PR TITLE
Fix logger arguments

### DIFF
--- a/RollingStockOwnership/CommsRadio/EquipmentPurchaser/DestinationPicker.cs
+++ b/RollingStockOwnership/CommsRadio/EquipmentPurchaser/DestinationPicker.cs
@@ -102,7 +102,7 @@ internal class DestinationPicker : AStateBehaviour
 			case InputAction.Activate:
 				if (IsPlaceable(selectedCarLivery, selectedTrack, selectedPoint))
 				{
-					Main.Log(() => $"Selected track: {selectedTrack.logicTrack.ID.FullID}");
+					Main.Log($"Selected track: {selectedTrack.logicTrack.ID.FullID}");
 					utility.PlaySound(VanillaSoundCommsRadio.Confirm);
 					return new PurchaseConfirmer(selectedCarLivery, selectedTrack, selectedPoint.Value, isSelectedOrientationOppositeTrackDirection, destinationHighlighter);
 				}

--- a/RollingStockOwnership/CommsRadio/EquipmentPurchaser/TrainCarLiveryPicker.cs
+++ b/RollingStockOwnership/CommsRadio/EquipmentPurchaser/TrainCarLiveryPicker.cs
@@ -42,7 +42,7 @@ internal class TrainCarLiveryPicker : AStateBehaviour
 				if (Finance.CanAfford(selectedCarLivery))
 				{
 					if (!carBounds.HasValue) { throw new Exception($"Can't find car bounds for car type: {selectedCarLivery.name}"); }
-					Main.Log(() => $"Selected livery: {selectedCarLivery.name}");
+					Main.Log($"Selected livery: {selectedCarLivery.name}");
 					utility.PlaySound(VanillaSoundCommsRadio.Confirm);
 					return new DestinationPicker(selectedCarLivery, carBounds.Value, utility.SignalOrigin);
 				}

--- a/RollingStockOwnership/Main.cs
+++ b/RollingStockOwnership/Main.cs
@@ -122,7 +122,7 @@ public static class Main
 
 	private static void LogAtLevel(Func<object> messageFactory, LogLevel level)
 	{
-		if (Settings.selectedLogLevel > level) { return; }
+		if (Settings.logLevel_v2 > level) { return; }
 
 		var message = messageFactory();
 		if (message is string messageString) { modEntry.Logger.Log(messageString); }
@@ -135,7 +135,7 @@ public static class Main
 
 	public static void Log(object message)
 	{
-		if (Settings.selectedLogLevel > LogLevel.Info) { return; }
+		if (Settings.logLevel_v2 > LogLevel.Info) { return; }
 
 		if (message is string messageString) { modEntry.Logger.Log(messageString); }
 		else if (message is Func<string> messageFactory) { modEntry.Logger.Log(messageFactory()); }
@@ -148,14 +148,14 @@ public static class Main
 
 	public static void LogWarning(string message)
 	{
-		if (Settings.selectedLogLevel > LogLevel.Warn) { return; }
+		if (Settings.logLevel_v2 > LogLevel.Warn) { return; }
 
 		modEntry.Logger.Warning(message);
 	}
 
 	public static void LogError(string message)
 	{
-		if (Settings.selectedLogLevel > LogLevel.Error) { return; }
+		if (Settings.logLevel_v2 > LogLevel.Error) { return; }
 
 		modEntry.Logger.Error(message);
 	}

--- a/RollingStockOwnership/Main.cs
+++ b/RollingStockOwnership/Main.cs
@@ -114,18 +114,18 @@ public static class Main
 		HarmonyMethod? transpiler = null
 	) => harmony.Patch(original, prefix, postfix, transpiler);
 
-	public static void LogVerbose(System.Func<object> messageFactory) =>
+	public static void LogVerbose(Func<object> messageFactory) =>
 		LogAtLevel(messageFactory, LogLevel.Verbose);
 
-	public static void LogDebug(System.Func<object> messageFactory) =>
+	public static void LogDebug(Func<object> messageFactory) =>
 		LogAtLevel(messageFactory, LogLevel.Debug);
 
-	private static void LogAtLevel(System.Func<object> messageFactory, LogLevel level)
+	private static void LogAtLevel(Func<object> messageFactory, LogLevel level)
 	{
 		if (Settings.selectedLogLevel > level) { return; }
 
 		var message = messageFactory();
-		if (message is string) { modEntry.Logger.Log(message as string); }
+		if (message is string messageString) { modEntry.Logger.Log(messageString); }
 		else
 		{
 			modEntry.Logger.Log("Logging object via UnityEngine.Debug...");
@@ -137,7 +137,8 @@ public static class Main
 	{
 		if (Settings.selectedLogLevel > LogLevel.Info) { return; }
 
-		if (message is string) { modEntry.Logger.Log(message as string); }
+		if (message is string messageString) { modEntry.Logger.Log(messageString); }
+		else if (message is Func<string> messageFactory) { modEntry.Logger.Log(messageFactory()); }
 		else
 		{
 			modEntry.Logger.Log("Logging object via UnityEngine.Debug...");
@@ -145,18 +146,18 @@ public static class Main
 		}
 	}
 
-	public static void LogWarning(object message)
+	public static void LogWarning(string message)
 	{
 		if (Settings.selectedLogLevel > LogLevel.Warn) { return; }
 
-		modEntry.Logger.Warning($"{message}");
+		modEntry.Logger.Warning(message);
 	}
 
-	public static void LogError(object message)
+	public static void LogError(string message)
 	{
 		if (Settings.selectedLogLevel > LogLevel.Error) { return; }
 
-		modEntry.Logger.Error($"{message}");
+		modEntry.Logger.Error(message);
 	}
 
 	public static void OnCriticalFailure(Exception exception, string action)

--- a/RollingStockOwnership/ProceduralJobGenerators.cs
+++ b/RollingStockOwnership/ProceduralJobGenerators.cs
@@ -157,7 +157,7 @@ public static class ProceduralJobGenerators
 		warehouseMachinesThatSupportCargoTypes.RemoveAll((machine) => machine.WarehouseTrack.length < (double)approxLengthOfWholeTrain);
 		if (warehouseMachinesThatSupportCargoTypes.Count == 0)
 		{
-			Main.LogWarning(() => $"Station[{destinationController.logicStation.ID}] doesn't have a warehouse track long enough for the job. ({approxLengthOfWholeTrain})");
+			Main.LogWarning($"Station[{destinationController.logicStation.ID}] doesn't have a warehouse track long enough for the job. ({approxLengthOfWholeTrain})");
 			return null;
 		}
 		WarehouseMachine warehouseMachine = warehouseMachinesThatSupportCargoTypes.ElementAtRandom(rng);
@@ -165,7 +165,7 @@ public static class ProceduralJobGenerators
 		List<CarsPerTrack>? randomSortingOfCarsOnTracks = Utilities.GetRandomSortingOfCarsOnTracks(rng, destinationController.logicStation.yard.StorageTracks, carsForJob, generationRuleset.maxShuntingStorageTracks, generationRuleset.minCarsPerJob);
 		if (randomSortingOfCarsOnTracks == null)
 		{
-			Main.LogWarning(() => $"Station[{destinationController.logicStation.ID}] couldn't assign cars to storage tracks.");
+			Main.LogWarning($"Station[{destinationController.logicStation.ID}] couldn't assign cars to storage tracks.");
 			return null;
 		}
 
@@ -262,7 +262,7 @@ public static class ProceduralJobGenerators
 		warehouseMachinesThatSupportCargoTypes.RemoveAll((machine) => machine.WarehouseTrack.length < (double)approxLengthOfWholeTrain);
 		if (warehouseMachinesThatSupportCargoTypes.Count == 0)
 		{
-			Main.LogWarning(() => $"Station[{originController.logicStation.ID}] doesn't have a warehouse track long enough for the job. ({approxLengthOfWholeTrain})");
+			Main.LogWarning($"Station[{originController.logicStation.ID}] doesn't have a warehouse track long enough for the job. ({approxLengthOfWholeTrain})");
 			return null;
 		}
 		WarehouseMachine warehouseMachine = warehouseMachinesThatSupportCargoTypes.ElementAtRandom(rng);

--- a/RollingStockOwnership/ProceduralJobsController.cs
+++ b/RollingStockOwnership/ProceduralJobsController.cs
@@ -55,7 +55,7 @@ public class ProceduralJobsController
 		var proceduralRuleset = stationController.proceduralJobsRuleset;
 		var manager = RollingStockManager.Instance;
 
-		Main.Log(() => $"Player owns licenses: [{string.Join(", ", LicenseManager.Instance.GetAcquiredJobLicenses().Union<Thing_v2>(LicenseManager.Instance.GetGeneralAcquiredLicenses()).Select(license => license.name))}]");
+		Main.Log($"Player owns licenses: [{string.Join(", ", LicenseManager.Instance.GetAcquiredJobLicenses().Union<Thing_v2>(LicenseManager.Instance.GetGeneralAcquiredLicenses()).Select(license => license.name))}]");
 
 		lock (RollingStockManager.syncLock)
 		{
@@ -130,7 +130,7 @@ public class ProceduralJobsController
 				foreach (var car in playerCars) { carsInYard.Add(car); }
 			}
 
-			Main.Log(() => $"Found {carsInYard.Count()} cars in {yardId} yard and player's train.");
+			Main.Log($"Found {carsInYard.Count()} cars in {yardId} yard and player's train.");
 
 			// Get all cars with assigned jobs
 			var carsWithJobs = new HashSet<Car>();
@@ -156,13 +156,13 @@ public class ProceduralJobsController
 				carsWithJobs.UnionWith(jobCars.Select(trainCar => trainCar.logicCar));
 			}
 
-			Main.Log(() => $"Found {carsWithJobs.Count()} cars with jobs assigned.");
+			Main.Log($"Found {carsWithJobs.Count()} cars with jobs assigned.");
 
 			// Filter out cars with assigned jobs
 			yield return null;
 			carsInYard.ExceptWith(carsWithJobs);
 
-			Main.Log(() => $"Found {carsInYard.Count()} jobless cars in {yardId} yard and player's train.");
+			Main.Log($"Found {carsInYard.Count()} jobless cars in {yardId} yard and player's train.");
 
 			int stationMinWagonsPerJob = proceduralRuleset.minCarsPerJob;
 			int maxWagonsPerJob = Math.Min(proceduralRuleset.maxCarsPerJob, LicenseManager.Instance.GetMaxNumberOfCarsPerJobWithAcquiredJobLicenses());
@@ -177,7 +177,7 @@ public class ProceduralJobsController
 				where LicenseManager_Patches.IsLicensedForCargoTypes(cargoGroup.cargoTypes)
 				select cargoGroup
 			).ToList();
-			Main.Log(() => $"Licensed inbound cargo groups: [{string.Join(", ", licensedInboundCargoGroups.Select(cg => string.Join(", ", cg.cargoTypes)))}]");
+			Main.Log($"Licensed inbound cargo groups: [{string.Join(", ", licensedInboundCargoGroups.Select(cg => string.Join(", ", cg.cargoTypes)))}]");
 
 			yield return null;
 			List<CargoGroup> licensedOutboundCargoGroups = (
@@ -185,7 +185,7 @@ public class ProceduralJobsController
 				where LicenseManager_Patches.IsLicensedForCargoTypes(cargoGroup.cargoTypes)
 				select cargoGroup
 			).ToList();
-			Main.Log(() => $"Licensed outbound cargo groups: [{string.Join(", ", licensedOutboundCargoGroups.Select(cg => string.Join(", ", cg.cargoTypes)))}]");
+			Main.Log($"Licensed outbound cargo groups: [{string.Join(", ", licensedOutboundCargoGroups.Select(cg => string.Join(", ", cg.cargoTypes)))}]");
 
 			// TrainCar is necessary for some operations, so convert once upfront
 			HashSet<TrainCar> wagonsInYard = Utilities.ConvertLogicCarsToTrainCars(carsInYard).ToHashSet();
@@ -216,9 +216,9 @@ public class ProceduralJobsController
 				}
 
 				wagonsInYard.ExceptWith(wagonsForLoading);
-				Main.Log(() => $"Found {wagonsForLoading.Count} cars for shunting load jobs.");
+				Main.Log($"Found {wagonsForLoading.Count} cars for shunting load jobs.");
 			}
-			else { Main.Log(() => $"{yardId} doesn't support shunting load jobs."); }
+			else { Main.Log($"{yardId} doesn't support shunting load jobs."); }
 
 			if (haulStartingJobSupported)
 			{
@@ -242,9 +242,9 @@ public class ProceduralJobsController
 				}
 
 				wagonsInYard.ExceptWith(wagonsForHauling);
-				Main.Log(() => $"Found {wagonsForHauling.Count} cars for transport jobs.");
+				Main.Log($"Found {wagonsForHauling.Count} cars for transport jobs.");
 			}
-			else { Main.Log(() => $"{yardId} doesn't support transport jobs."); }
+			else { Main.Log($"{yardId} doesn't support transport jobs."); }
 
 			if (unloadStartingJobSupported)
 			{
@@ -268,9 +268,9 @@ public class ProceduralJobsController
 				}
 
 				wagonsInYard.ExceptWith(wagonsForUnloading);
-				Main.Log(() => $"Found {wagonsForUnloading.Count} cars for shunting unload jobs.");
+				Main.Log($"Found {wagonsForUnloading.Count} cars for shunting unload jobs.");
 			}
-			else { Main.Log(() => $"{yardId} doesn't support shunting unload jobs."); }
+			else { Main.Log($"{yardId} doesn't support shunting unload jobs."); }
 
 			if (wagonsInYard.Count > 0)
 			{
@@ -289,10 +289,10 @@ public class ProceduralJobsController
 				}
 
 				wagonsInYard.ExceptWith(wagonsForLogistics);
-				Main.Log(() => $"Found {wagonsForLogistics.Count} cars for logistic jobs.");
+				Main.Log($"Found {wagonsForLogistics.Count} cars for logistic jobs.");
 			}
 
-			Main.Log(() => $"Excluding {wagonsInYard.Count} cars as incompatible.");
+			Main.Log($"Excluding {wagonsInYard.Count} cars as incompatible.");
 
 			/**
 			 * SHUNTING LOAD

--- a/RollingStockOwnership/ReservationManager.cs
+++ b/RollingStockOwnership/ReservationManager.cs
@@ -189,7 +189,7 @@ public class ReservationManager
 			catch (Exception exception)
 			{
 				// log the exception, but continue trying to load
-				Main.LogWarning(exception);
+				Main.LogWarning(exception.ToString());
 			}
 		}
 		Main.Log($"Loaded {countLoaded}/{countTotal} reservations into the reservation manager.");

--- a/RollingStockOwnership/RollingStockManager.cs
+++ b/RollingStockOwnership/RollingStockManager.cs
@@ -120,7 +120,7 @@ public class RollingStockManager
 			catch (Exception exception)
 			{
 				// log the exception, but continue trying to load
-				Main.LogWarning(exception);
+				Main.LogWarning(exception.ToString());
 			}
 		}
 		Main.Log($"Loaded {countLoaded}/{countTotal} equipment records into the rolling stock registry.");

--- a/RollingStockOwnership/Settings.cs
+++ b/RollingStockOwnership/Settings.cs
@@ -5,11 +5,11 @@ namespace RollingStockOwnership;
 public class Settings : UnityModManager.ModSettings, IDrawable
 {
 	[Draw("Log level")]
-	public LogLevel selectedLogLevel =
+	public LogLevel logLevel_v2 = // versioning let's us reset players' selected log level
 #if DEBUG
 		LogLevel.Debug;
 #else
-		LogLevel.Warn;
+		LogLevel.Info;
 #endif
 
 	[Draw("Sandbox price multiplier", Min = 0f, Max = 1f)]


### PR DESCRIPTION
Some logger methods that excepted a string were being passed a message factory instead. This fixes those calls and updates the logger methods to prevent such accidents in the future.

This also sets the default log level for release builds to `Info` so that logs contain sufficient information to investigate reported issues.