### PR TITLE
Prompt player to choose starter equipment

### DIFF
--- a/RollingStockOwnership/Settings.cs
+++ b/RollingStockOwnership/Settings.cs
@@ -15,9 +15,6 @@ public class Settings : UnityModManager.ModSettings, IDrawable
 	[Draw("Sandbox price multiplier", Min = 0f, Max = 1f)]
 	public float sandboxPriceMultiplier = 0f;
 
-	[Draw("Starter locomotive")]
-	public StarterLocoType starterLocoType = StarterLocoType.LocoDE2;
-
 	public void OnChange() { }
 
 	public override void Save(UnityModManager.ModEntry modEntry)

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -116,9 +116,9 @@ internal static class StartingConditions
 			return PopupAPI.Show3Buttons(
 				title: "Rolling Stock Ownership",
 				message: message,
-				positive: LocalizationAPI.L(locoOptions[0].ToV2().localizationKey),
-				negative: LocalizationAPI.L(locoOptions[1].ToV2().localizationKey),
-				abort: LocalizationAPI.L(locoOptions[2].ToV2().localizationKey)
+				positive: LocalizationAPI.L(locoOptions[0].ToV2().parentType.localizationKey),
+				negative: LocalizationAPI.L(locoOptions[1].ToV2().parentType.localizationKey),
+				abort: LocalizationAPI.L(locoOptions[2].ToV2().parentType.localizationKey)
 			);
 		}).Then((popupResult) => {
 			PopupClosedByAction pressedButton = popupResult.closedBy;
@@ -132,9 +132,9 @@ internal static class StartingConditions
 			return PopupAPI.Show3Buttons(
 				title: "Rolling Stock Ownership",
 				message: Main.Localize("choose_starter_wagon"),
-				positive: LocalizationAPI.L(wagonOptions[0].ToV2().localizationKey),
-				negative: LocalizationAPI.L(wagonOptions[1].ToV2().localizationKey),
-				abort: LocalizationAPI.L(wagonOptions[2].ToV2().localizationKey)
+				positive: LocalizationAPI.L(wagonOptions[0].ToV2().parentType.localizationKey),
+				negative: LocalizationAPI.L(wagonOptions[1].ToV2().parentType.localizationKey),
+				abort: LocalizationAPI.L(wagonOptions[2].ToV2().parentType.localizationKey)
 			);
 		}).Then((popupResult) => {
 			PopupClosedByAction pressedButton = popupResult.closedBy;
@@ -232,11 +232,11 @@ internal static class StartingConditions
 
 		public string LocalizedSelectedLocomotive
 		{
-			get { return LocalizationAPI.L(SelectedLocomotiveType.ToV2().localizationKey); }
+			get { return LocalizationAPI.L(SelectedLocomotiveType.ToV2().parentType.localizationKey); }
 		}
 		public string LocalizedSelectedWagon
 		{
-			get { return LocalizationAPI.L(SelectedWagonType.ToV2().localizationKey); }
+			get { return LocalizationAPI.L(SelectedWagonType.ToV2().parentType.localizationKey); }
 		}
 
 		public void ChooseLocomotive(TrainCarType locomotiveType)

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -107,7 +107,12 @@ internal static class StartingConditions
 
 		var choices = new StarterChoices();
 		var locoOptions = new List<TrainCarType> { TrainCarType.LocoShunter, TrainCarType.LocoDM3, TrainCarType.LocoS060 };
-		var wagonOptions = new List<TrainCarType> { TrainCarType.StockBrown, TrainCarType.TankShortMilk, TrainCarType.GondolaGray };
+		var wagonOptions = new List<TrainCarType>
+		{
+			TrainCarType.StockBrown, // single route, lowest average pay, lowest average tonnage, highest average pay to tonnage ratio
+			TrainCarType.GondolaGray, // more routes, medium average pay, medium average tonnage, medium average pay to tonnage ratio
+			TrainCarType.HopperTeal // most routes, highest average pay, highest average tonnage, lowest average pay to tonnage ratio
+		};
 
 		// Randomize the order of the displayed option
 		locoOptions.Sort((_, _) => random.NextDouble() < 0.5 ? -1 : 1);

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -13,6 +13,7 @@ using DV.ThingTypes.TransitionHelpers;
 using DV.UIFramework;
 using HarmonyLib;
 using MessageBox;
+using RollingStockOwnership.Extensions;
 using UnityEngine;
 
 namespace RollingStockOwnership;
@@ -72,9 +73,15 @@ internal static class StartingConditions
 		Inventory inventory = Inventory.Instance;
 		UnusedTrainCarDeleter unusedTrainCarDeleter = UnusedTrainCarDeleter.Instance;
 		CarSpawner carSpawner = CarSpawner.Instance;
-		TrainCarLivery starterLoco = choices.SelectedLocomotiveType.ToV2();
-		TrainCarLivery starterWagon = choices.SelectedWagonType.ToV2();
-		List<TrainCarLivery> liveries = new List<TrainCarLivery> { starterLoco, starterWagon, starterWagon, starterWagon };
+		TrainCarLivery starterLoco = choices.SelectedLocomotiveType.ToV2().parentType.liveries.ElementAtRandom(random);
+		List<TrainCarLivery> starterWagonLiveries = choices.SelectedWagonType.ToV2().parentType.liveries;
+		List<TrainCarLivery> starterLiveries = new List<TrainCarLivery>
+		{
+			starterLoco,
+			starterWagonLiveries.ElementAtRandom(random),
+			starterWagonLiveries.ElementAtRandom(random),
+			starterWagonLiveries.ElementAtRandom(random)
+		};
 
 		LicenseManager.Instance.AcquireGeneralLicense(starterLoco.requiredLicense);
 		if (CarTypes.IsSteamLocomotive(starterLoco))
@@ -88,7 +95,7 @@ internal static class StartingConditions
 		bool randomOrientation = false;
 		bool playerSpawnedCar = false;
 		IEnumerable<Equipment> spawnedEquipment =
-			carSpawner.SpawnCarTypesOnTrackStrict(liveries, track, true, true, startSpan, flipConsist, randomOrientation, playerSpawnedCar)
+			carSpawner.SpawnCarTypesOnTrackStrict(starterLiveries, track, true, true, startSpan, flipConsist, randomOrientation, playerSpawnedCar)
 			.Select(Equipment.FromTrainCar);
 
 		spawnedEquipment.Do(RollingStockManager.Instance.Add);

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -7,6 +7,7 @@ using DV.InventorySystem;
 using DV.Localization;
 using DV.Logic.Job;
 using DV.Shops;
+using DV.Teleporters;
 using DV.ThingTypes;
 using DV.ThingTypes.TransitionHelpers;
 using DV.UIFramework;
@@ -152,7 +153,21 @@ internal static class StartingConditions
 				positive: Main.Localize("teleport_to_starter_equipment_positive")
 			);
 		}).Then((_) => {
-			// TODO: how to teleport the player?
+			var teleportTarget = GameObject.Find("TeleportHouse");
+			if (teleportTarget == null)
+			{
+				throw new Exception("Failed to find player house teleport target");
+			}
+
+			var teleporter = teleportTarget.GetComponent<NonStationTeleporter>();
+			if (teleporter == null)
+			{
+				throw new Exception("Failed to find player house teleporter");
+			}
+
+			teleporter.TeleportToStation();
+		}).Catch((exception) => {
+			Main.LogError($"Exception thrown while displaying first run messages: {exception}");
 		});
 	}
 

--- a/RollingStockOwnership/StartingConditions.cs
+++ b/RollingStockOwnership/StartingConditions.cs
@@ -113,7 +113,7 @@ internal static class StartingConditions
 		var wagonOptions = new List<TrainCarType>
 		{
 			TrainCarType.StockBrown, // single route, lowest average pay, lowest average tonnage, highest average pay to tonnage ratio
-			TrainCarType.GondolaGray, // more routes, medium average pay, medium average tonnage, medium average pay to tonnage ratio
+			TrainCarType.FlatbedStakes, // more routes, medium average pay, medium average tonnage, medium average pay to tonnage ratio
 			TrainCarType.HopperTeal // most routes, highest average pay, highest average tonnage, lowest average pay to tonnage ratio
 		};
 


### PR DESCRIPTION
Having recently had to explain to someone how the starter locomotive mod setting worked, I realized how obtuse of a user experience it was. I also made the connection that there are three options for starter loco and a maximum of three buttons on the DV popup prompts. Therefore, it seemed logical to create prompts that guide the player through selection of starter loco during initial setup rather than use a mod setting for this purpose.

While making this change, I also realized the same mechanism could be used to select starter wagons. This would alleviate another pain point of having to explain to players via popup message text that they've been given money and need to buy wagons with it. Livestock wagons, flatbeds with stakes, and hoppers were chosen as the starter wagon options based on the following rationale/trade-offs:

- livestock wagons
  - single route
  - lowest average pay
  - lowest average tonnage
  - highest average pay to tonnage ratio
  - milk tanks could also fill this role
    - might be more challenging due to liquid cargo's ability to leak out of damaged wagons
- flatbeds with stakes
  - more routes
  - medium average pay
  - medium average tonnage
  - medium average pay to tonnage ratio
- hoppers
  - most routes
  - highest average pay
  - highest average tonnage
  - lowest average pay to tonnage ratio

The ordering of the options is randomized so that none consistently receives undue preference based on ordering.

Also, selection of the starter equipment spawn track is now based on the player house teleport anchor. This makes the code more resilient to future map updates or the addition of entirely new maps.

![20240424123357_1](https://github.com/fauxnik/dv-rolling-stock-ownership/assets/66900153/7fc6411d-b77d-4f33-9dc5-07945a59dbb8)
_A welcome message shown to the player the first time a save is loaded with RSO active._

![20240424123414_1](https://github.com/fauxnik/dv-rolling-stock-ownership/assets/66900153/ce0a2db7-2bbb-4c00-b0f3-96496c34fbc6)
_A message explaining to the player that they've been given the shunting license and asking them to select a locomotive type._

![20240424123808_1](https://github.com/fauxnik/dv-rolling-stock-ownership/assets/66900153/c9f8511b-bb0c-4b9a-9d4a-a01b5eed5f8d)
_An alternate message displayed if the player already owned the shunting license. It only asks them to select a locomotive type._

![20240424124656_1](https://github.com/fauxnik/dv-rolling-stock-ownership/assets/66900153/7b399aa2-b782-46a0-8287-316bc5eb29b5)
_A message asking the player to select a wagon type._

![20240424123428_1](https://github.com/fauxnik/dv-rolling-stock-ownership/assets/66900153/d743c733-fa7d-4e76-81bd-4c351ef0538c)
_A message confirming equipment spawn and informing the player they will be teleported to the player house._

![20240424123449_1](https://github.com/fauxnik/dv-rolling-stock-ownership/assets/66900153/f47dbc53-bf77-4eb2-a8f8-e80bd96cdc9d)
_A view from the player house after being teleported there._