### PR TITLE
Ensure reservations are loaded/setup properly

### DIFF
--- a/RollingStockOwnership/Equipment.cs
+++ b/RollingStockOwnership/Equipment.cs
@@ -89,7 +89,12 @@ public class Equipment
 	private bool isExploded;
 
 	private static readonly string LOADED_CARGO_SAVE_KEY = "loadedCargo";
-	private CargoType loadedCargo;
+	private CargoType _loadedCargo;
+	public CargoType LoadedCargo
+	{
+		get => _loadedCargo;
+		private set { _loadedCargo = value; }
+	}
 
 	private static readonly string HANDBRAKE_SAVE_KEY = "handbrake";
 	private float? handbrakeApplication;
@@ -143,7 +148,7 @@ public class Equipment
 		this.CarGuidCoupledFront = carGuidCoupledFront;
 		this.CarGuidCoupledRear = carGuidCoupledRear;
 		this.isExploded = isExploded;
-		this.loadedCargo = loadedCargo;
+		this.LoadedCargo = loadedCargo;
 		this.handbrakeApplication = handbrakeApplication;
 		this.mainReservoirPressure = mainReservoirPressure;
 		this.controlReservoirPressure = controlReservoirPressure;
@@ -228,7 +233,7 @@ public class Equipment
 	private void UpdateCargo(TrainCar? trainCar)
 	{
 		if (trainCar == null) { return; }
-		loadedCargo = trainCar.logicCar.CurrentCargoTypeInCar;
+		LoadedCargo = trainCar.logicCar.CurrentCargoTypeInCar;
 	}
 
 	private void SetupCouplerEventHandlers(TrainCar? trainCar)
@@ -335,7 +340,7 @@ public class Equipment
 		bool isUniqueCar = false;
 		trainCar = CarSpawner.Instance.SpawnLoadedCar(carPrefab, ID, CarGUID, isPlayerSpawnedCar, isUniqueCar, position + WorldMover.currentMove, rotation, isBogie1Derailed, bogie1Track, bogie1PositionAlongTrack, isBogie2Derailed, bogie2Track, bogie2PositionAlongTrack, IsCoupledFront, IsCoupledRear);
 
-		if (loadedCargo != CargoType.None) { trainCar.logicCar.LoadCargo(trainCar.cargoCapacity, loadedCargo, null); }
+		if (LoadedCargo != CargoType.None) { trainCar.logicCar.LoadCargo(trainCar.cargoCapacity, LoadedCargo, null); }
 		if (isExploded) { TrainCarExplosion.UpdateModelToExploded(trainCar); }
 
 		if (handbrakeApplication.HasValue) { trainCar.brakeSystem.SetHandbrakePosition(handbrakeApplication.Value); }
@@ -597,7 +602,7 @@ public class Equipment
 		{
 			data.SetFloat(BRAKE_CYLINDER_PRESSURE_SAVE_KEY, brakeCylinderPressure.Value);
 		}
-		data.SetInt(LOADED_CARGO_SAVE_KEY, (int)loadedCargo);
+		data.SetInt(LOADED_CARGO_SAVE_KEY, (int)LoadedCargo);
 		data.SetJObject(CAR_STATE_SAVE_KEY, carStateSave);
 		data.SetJObject(SIM_CAR_STATE_SAVE_KEY, simCarStateSave);
 		data.SetBool(SPAWNED_SAVE_KEY, IsSpawned);

--- a/RollingStockOwnership/Main.cs
+++ b/RollingStockOwnership/Main.cs
@@ -95,7 +95,6 @@ public static class Main
 		CommsRadioAPI.ControllerAPI.Ready += CommsRadio.JobRequesterMode.Create;
 
 		WorldStreamingInit.LoadingFinished += StartingConditions.Verify;
-		WorldStreamingInit.LoadingFinished += ReservationManager.SetupReservationCallbacks;
 	}
 
 	internal static string Localize(string nakedKey, params string[] paramValues) =>

--- a/RollingStockOwnership/SaveManager.cs
+++ b/RollingStockOwnership/SaveManager.cs
@@ -48,6 +48,11 @@ public class SaveManager
 	[HarmonyPatch(typeof(CarsSaveManager), "Load")]
 	class SaveGameManager_Load_Patch
 	{
+		static void Prefix()
+		{
+			// These callbacks must be setup before the saved wagons are spawned
+			ReservationManager.SetupReservationCallbacks();
+		}
 
 		static void Postfix(SaveGameManager __instance)
 		{


### PR DESCRIPTION
Reservation callbacks were being setup too late to be applied to wagons loaded from save.

Checking reservation cargo against `TrainCar` instances is fraught because the player may be far enough away that the equipment has despawned. Comparing against `Equipment` works because these records persist even if the wagon is despawned due to lack of proximity.

Empty wagons that are part of a Shunting Unload job must skip reservation force-creation if they've already been unloaded. This would otherwise create reservations with `CargoType.None`, which is both unexpected and breaks logic therein.